### PR TITLE
[fix] GID가 이미 존재할 경우 groupadd 생략 (macOS 대응)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ARG USER
 ARG USER_UID
 ARG USER_GID
 ARG PROJECT_ID
-RUN groupadd --gid $USER_GID $USER \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USER
+RUN getent group ${USER_GID} || groupadd --gid ${USER_GID} ${USER} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USER}
 
 # Prerequisite
 RUN apt-get update && apt-get install -y \

--- a/start.sh
+++ b/start.sh
@@ -68,12 +68,12 @@ pk_mount="/home/$user/.ssh/$pk_basename"
 if ! docker image inspect "$image_name" > /dev/null 2>&1; then
     echo "Image '$image_name' does not exist. Building..."
     docker build -t "$image_name" \
-        --build-arg USER="$user" \
-        --build-arg USER_UID="$uid" \
-        --build-arg USER_GID="$gid" \
-        --build-arg PROJECT_ID=$(grep '"project_id"' key.json | head -1 | sed -E 's/.*: "(.*)",?/\1/')
-        "$dockerfile_dir" \
-        || { echo "Build failed"; exit 1; }
+    --build-arg USER="$user" \
+    --build-arg USER_UID="$uid" \
+    --build-arg USER_GID="$gid" \
+    --build-arg PROJECT_ID=$(grep '"project_id"' key.json | head -1 | sed -E 's/.*: "(.*)",?/\1/') \
+    "$dockerfile_dir" \
+    || { echo "Build failed"; exit 1; }
 fi
 
 # Check for container presence and then run it... or not


### PR DESCRIPTION
## 📌 [fix] GID가 이미 존재할 경우 groupadd 생략 (macOS 대응)

## ✨ 변경 사항  
- macOS 환경에서는 GID 20이 기본적으로 staff 그룹에 할당되어 있어 groupadd 실행 시 충돌이 발생함
- getent group을 사용하여 GID가 이미 존재하는 경우 groupadd를 생략하도록 Dockerfile을 수정함
- 이를 통해 GID 충돌 없이 dev-container 이미지 빌드가 가능하도록 개선함

## 📂 변경된 파일  
- `Dockerfile`
- `start.sh`

## 🚀 변경 유형  
- [ ] ✨ 기능 추가 (새로운 기능)  
- [x] 🐛 버그 수정 (기존 기능 수정)  
- [ ] ♻️ 리팩토링 (코드 구조 개선)  
- [ ] 📝 문서 수정 (README 등 문서 변경)  
- [ ] 🚨 테스트 추가/수정  

## ✅ 체크리스트  
PR을 올리기 전에 아래 사항을 확인해주세요.  
- [x] 코드가 정상적으로 실행됨  
- [ ] 관련 테스트 코드를 추가함  
- [x] 기존 기능에 영향을 주지 않음  
- [ ] 문서를 업데이트했음 (필요한 경우)  

## 💬 기타 참고 사항  
- macOS 기준, GID 20은 기본적으로 staff 그룹으로 할당되어 있음
- 컨테이너 내부에서 마운트된 볼륨 경로에 대해 echo >, cat 테스트 모두 정상적으로 동작 확인됨 (permission 확인)
- GID 충돌로 인한 Docker build 실패를 방지하기 위한 최소한의 수정 입니다.
